### PR TITLE
header/footer only as wide as the content.

### DIFF
--- a/app/assets/stylesheets/locals/navbar.css.scss
+++ b/app/assets/stylesheets/locals/navbar.css.scss
@@ -7,7 +7,26 @@
     .contact {
         a { color: $light-green; }
     }
+
     li > a { // Matching default to override
         padding: 15px 0 0 30px; // TODO: replace with $gutter
     }
+
+    /* 
+      These come from bootstrap/_grid.scss,
+      but we don't want want everything else 
+      that comes with being a container.
+    */
+    @media (min-width: $screen-sm-min) {
+        width: $container-sm;
+    }
+    @media (min-width: $screen-md-min) {
+        width: $container-md;
+    }
+    @media (min-width: $screen-lg-min) {
+        width: $container-lg;
+    }
+    // Centering:
+    margin-right: auto;
+    margin-left: auto;
 }


### PR DESCRIPTION
No issue was filed, but it was pointed out that banners should only be as wide as the content. This does that.
![screen shot 2015-09-28 at 2 06 12 pm](https://cloud.githubusercontent.com/assets/730388/10144245/8fdd462e-65ea-11e5-93cb-45038160863d.png)
