### PR TITLE
grid spacing and font-size as requested.

### DIFF
--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -121,3 +121,7 @@ p {
     // want the edge gutters just as wide.
     padding: 0 $grid-gutter-width;
 }
+
+body {
+    font-size: 1.25em;
+}

--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -121,7 +121,3 @@ p {
     // want the edge gutters just as wide.
     padding: 0 $grid-gutter-width;
 }
-
-body {
-    font-size: 1.25em;
-}

--- a/app/assets/stylesheets/locals/thumb.css.scss
+++ b/app/assets/stylesheets/locals/thumb.css.scss
@@ -11,5 +11,5 @@
         margin-top: 0.5em;
         color: $dark-blue; // This might apply to <a>s more generally
     }
-    margin-bottom: 40px;
+    margin-bottom: $grid-gutter-width;
 }

--- a/app/assets/stylesheets/locals/thumb.css.scss
+++ b/app/assets/stylesheets/locals/thumb.css.scss
@@ -11,5 +11,5 @@
         margin-top: 0.5em;
         color: $dark-blue; // This might apply to <a>s more generally
     }
-    margin-bottom: 1.5em;
+    margin-bottom: 40px;
 }

--- a/app/assets/stylesheets/locals/thumb.css.scss
+++ b/app/assets/stylesheets/locals/thumb.css.scss
@@ -1,4 +1,5 @@
 .thumb {
+    font-size: 12px;
     img {
         display: block;
         width: 400px; 


### PR DESCRIPTION
Fix #72. @lisarosenthal / @afred : please review. I've also changed the font size to match the 1.25em of the spec. The result is a proportionally greater space between the grid cells than in the last mockups: It feels like it could be too much, but I'm not going to argue the point. (left: with this PR; no zoom, but the screen grab is resized here. right: mockup.)

![screen shot 2015-09-30 at 10 42 43 am](https://cloud.githubusercontent.com/assets/730388/10196378/9e44d778-6760-11e5-9f33-3c42e14e1ce0.png)
