### PR TITLE
_blank if outsite. Kind of hacky. Fix #152.

### DIFF
--- a/app/views/shared/_thumb_3.html.erb
+++ b/app/views/shared/_thumb_3.html.erb
@@ -1,5 +1,5 @@
 <div class="col-md-4 thumb">
-  <a href="<%= item.url %>">
+  <a href="<%= item.url %>" <%= 'target="_blank"' if item.url =~ /^https?:/ %> >
     <img src="<%= item.thumb_src %>">
     <div class="title"><%= item.title.html_safe %></div>
     <% if item.short_html %>


### PR DESCRIPTION
@afred: please review. (On the home page this partial is used for internal links, but on the collection pages the links are external.)