### PR TITLE
Refactor catalog show view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,4 +58,5 @@ gem 'simplecov', :require => false, :group => :test
 group :development, :test do
   gem 'pry'
   gem 'faraday'
+  gem 'byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
     builder (3.2.2)
+    byebug (6.0.2)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -173,7 +174,7 @@ GEM
     simplecov-html (0.8.0)
     slop (3.6.0)
     sony-ci-api (0.1.1)
-    spring (1.3.3)
+    spring (1.4.0)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -206,6 +207,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk (~> 2)
   blacklight
+  byebug
   capybara
   cmless (= 0.0.9)
   coffee-rails (~> 4.0.0)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -29,3 +29,4 @@
 @import "locals/catalog-index";
 @import "locals/catalog-show";
 @import "locals/search_form";
+@import "locals/field_list";

--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -112,8 +112,10 @@ p {
 }
 
 .col-md-12 {
-    // Default gives us gutters at the edges which are
-    // half the gutters in between the cells. We actually
-    // want the edge gutters just as wide.
-    padding: 0 $grid-gutter-width;
+  // Default gives us gutters at the edges which are
+  // half the gutters in between the cells. We actually
+  // want the edge gutters just as wide.
+  // TODO: find a way to do this that doesn't affect *all* grids so we don't
+  //  have to reset it in other places, e.g. field_list.scss
+  padding: 0 $grid-gutter-width;
 }

--- a/app/assets/stylesheets/locals/field_list.scss
+++ b/app/assets/stylesheets/locals/field_list.scss
@@ -1,0 +1,6 @@
+.field-list {
+  .col-md-12 {
+    // Wresting control of column padding from blacklight.css.scss
+    padding: 0 ($grid-gutter-width / 2);
+  }
+}

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -3,7 +3,7 @@ class MediaController < ApplicationController
   
   def show
     @response, @document = fetch(params['id'])
-    ci_id = Asset.new(JSON.parse(@document.instance_variable_get('@_source')['json'])).ci_id
+    ci_id = @document.ci_id
     # TODO: Move multi_details to SonyCiBasic?
     # TODO: ... or add a method just for this?
     ci = SonyCiAdmin.new(credentials_path: Rails.root + 'config/ci.yml')

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,3 +1,23 @@
 class SolrDocument 
   include Blacklight::Solr::Document
+
+  attr_accessor :json
+
+  def json
+    @json ||= (JSON.parse(@_source[:json]) rescue {}).with_indifferent_access
+  end
+
+  def label_for(field)
+    # Assume labels are the same as field names, sans underscores and
+    # "clip_" prefix if it has one.
+    field.to_s.gsub('_',' ').gsub(/clip /i, '')
+  end
+
+  def value_of(field)
+    @_source[field] || json[field]
+  end
+
+  def labels_and_values(*fields)
+    fields.map{ |field| {label: label_for(field), value: value_of(field)} }.select{ |pair| !pair[:value].nil? && !pair[:value].empty? }
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -8,14 +8,8 @@ class SolrDocument
     @json ||= (JSON.parse(@_source[:json]) rescue {}).with_indifferent_access
   end
 
-  def label_for(field)
-    # Assume labels are the same as field names, sans underscores and
-    # "clip_" prefix if it has one.
-    field.to_s.gsub('_',' ').gsub(/clip /i, '')
-  end
-
   def labels_and_values(*fields)
-    fields.map{ |field| { label: label_for(field), value: send(field) } }.select{ |pair| !pair[:value].nil? && !pair[:value].empty? }
+    fields.map{ |field| { label: SolrDocument.label_for(field), value: send(field) } }.select{ |pair| !pair[:value].nil? && !pair[:value].empty? }
   end
 
   def artesia_id
@@ -108,5 +102,13 @@ class SolrDocument
 
   def watermarked_src
     "/downloads/#{id}"
+  end
+
+  # CLASS METHODS
+
+  def self.label_for(field)
+    # Assume labels are the same as field names, sans underscores and
+    # "clip_" prefix if it has one.
+    field.to_s.gsub('_',' ').gsub(/clip /i, '')
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,4 +1,5 @@
-class SolrDocument 
+class SolrDocument
+
   include Blacklight::Solr::Document
 
   attr_accessor :json
@@ -13,11 +14,99 @@ class SolrDocument
     field.to_s.gsub('_',' ').gsub(/clip /i, '')
   end
 
-  def value_of(field)
-    @_source[field] || json[field]
+  def labels_and_values(*fields)
+    fields.map{ |field| { label: label_for(field), value: send(field) } }.select{ |pair| !pair[:value].nil? && !pair[:value].empty? }
   end
 
-  def labels_and_values(*fields)
-    fields.map{ |field| {label: label_for(field), value: value_of(field)} }.select{ |pair| !pair[:value].nil? && !pair[:value].empty? }
+  def artesia_id
+    json[:artesia_id]
+  end
+  def aspect_ratio
+    json[:aspect_ratio]
+  end
+  def barcode
+    json[:barcode]
+  end
+  def category
+    json[:category]
+  end
+  def ci_id
+    json[:ci_id]
+  end
+  def clip_description
+    json[:clip_description]
+  end
+  def clip_keywords
+    json[:clip_keywords]
+  end
+  def clip_title
+    json[:clip_title]
+  end
+  def codec
+    json[:codec]
+  end
+  def digital_wrapper
+    json[:digital_wrapper]
+  end
+  def dimensions
+    json[:dimensions]
+  end
+  def drive_name
+    json[:drive_name]
+  end
+  def episode_number
+    json[:episode_number]
+  end
+  def event_date
+    json[:event_date]
+  end
+  def event_location
+    json[:event_location]
+  end
+  def file_name
+    json[:file_name]
+  end
+  def folder_name
+    json[:folder_name]
+  end
+  def format
+    json[:format]
+  end
+  def frames_per_second
+    json[:frames_per_second]
+  end
+  def id
+    json[:id]
+  end
+  def length
+    json[:length]
+  end
+  def origin
+    json[:origin]
+  end
+  def program
+    json[:program]
+  end
+  def proxy_src
+    "/media/#{id}"
+  end
+  def series
+    json[:series]
+  end
+  def tape_number
+    json[:tape_number]
+  end
+  def thumb_src
+    json[:thumb_src]
+  end
+  def time_in
+    json[:time_in]
+  end
+  def type
+    json[:type]
+  end
+
+  def watermarked_src
+    "/downloads/#{id}"
   end
 end

--- a/app/views/catalog/_field_list.html.erb
+++ b/app/views/catalog/_field_list.html.erb
@@ -1,20 +1,22 @@
 <%
-# default to 1 column, and only allow up to 4
+# TODO: I don't like checking param values and setting defaults here.
+#  Find a better way?
+
 columns ||= 1
-columns = [columns.to_i, 4].min
+columns = columns.to_i
+raise "Value of `columns' passed to field_list partial should be between 1 and 4, but #{columns} was given" unless columns.between?(1,4)
+
 bootstrap_colspan = 12 / columns
 %>
 
 
 <div class="row field-list">
-  <% field_list.in_groups(columns) do |field_group| %>
+  <% field_list.in_groups(columns, false) do |field_group| %>
     <div class="col-md-<%= bootstrap_colspan %>">
       <dl>
         <% field_group.each do |field| %>
-          <% unless field.nil? %>
-            <dt><%= field[:label] %></dt>
-            <dd><%= field[:value] %></dd>
-          <% end %>
+          <dt><%= field[:label] %></dt>
+          <dd><%= field[:value] %></dd>
         <% end %>
       </dl>
     </div>

--- a/app/views/catalog/_field_list.html.erb
+++ b/app/views/catalog/_field_list.html.erb
@@ -1,10 +1,22 @@
-<dl>
-  <% fields.each do |method| 
-    asset.send(method).tap do |value| 
-      if !value.empty? %>
-        <dt><%= method.gsub('_',' ').gsub(/clip /i, '') %></dt>
-        <dd><%= value %></dd><% 
-      end
-    end
-  end %>
-</dl>
+<%
+# default to 1 column, and only allow up to 4
+columns ||= 1
+columns = [columns.to_i, 4].min
+bootstrap_colspan = 12 / columns
+%>
+
+
+<div class="row field-list">
+  <% field_list.in_groups(columns) do |field_group| %>
+    <div class="col-md-<%= bootstrap_colspan %>">
+      <dl>
+        <% field_group.each do |field| %>
+          <% unless field.nil? %>
+            <dt><%= field[:label] %></dt>
+            <dd><%= field[:value] %></dd>
+          <% end %>
+        <% end %>
+      </dl>
+    </div>
+  <% end %>
+</div>

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -1,14 +1,12 @@
-<% Asset.new(JSON.parse(document.instance_variable_get('@_source')['json'])).tap do |asset| %>
-  <div>
-    <div class="video-container">
-      <video src="<%= asset.proxy_src %>" poster="<%= asset.thumb_src %>" 
-             loop oncontextmenu="return false;" preload="none"
-             onmouseover="this.play();" onmouseout="this.pause();" <%# For browsers %>
-             onclick="this.paused ? this.play() : this.pause();" <%# For touch devices %>
-             >
-      </video>      
-    </div>
-    <a href="/catalog/<%= asset.id %>"><%= asset.clip_title %></a>
-    <a href="<%= asset.watermarked_src %>" target="_blank" class="pull-right"><span class="glyphicon glyphicon-download-alt"></span></a>
+<div>
+  <div class="video-container">
+    <video src="<%= document.proxy_src %>" poster="<%= document.thumb_src %>" 
+           loop oncontextmenu="return false;" preload="none"
+           onmouseover="this.play();" onmouseout="this.pause();" <%# For browsers %>
+           onclick="this.paused ? this.play() : this.pause();" <%# For touch devices %>
+           >
+    </video>      
   </div>
-<% end %>
+  <a href="/catalog/<%= document.id %>"><%= document.clip_title %></a>
+  <a href="<%= document.watermarked_src %>" target="_blank" class="pull-right"><span class="glyphicon glyphicon-download-alt"></span></a>
+</div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,49 +1,47 @@
-<% Asset.new(JSON.parse(@document.instance_variable_get('@_source')['json'])).tap do |asset| %>
-  <div id="content" class="container">
-    <div class="row">
-      <div class="pull-left col-md-9">
-        <h1><%= asset.clip_title %></h1>
-      </div>
-      <div class="pull-right col-md-3">
-        <%= render partial: 'shared/search', locals: {placeholder: "New search"} %>
-      </div>
+<div id="content" class="container">
+  <div class="row">
+    <div class="pull-left col-md-9">
+      <h1><%= @document.clip_title %></h1>
     </div>
-    <div class="row">
-      <div class="col-md-6">
-        <video controls="true"
-          oncontextmenu="return false;" 
-          width="100%"
-          poster="<%= asset.thumb_src %>"
-          src="<%= asset.proxy_src %>">
-        </video>
-        <p>
-          TODO: Allison, put your message here.
-        </p>
-      </div>
-
-      <div class="col-md-6">
-      <%= render partial: 'catalog/field_list',
-                 locals: { columns: 1,
-                           field_list: @document.labels_and_values( :clip_description,
-                                                                    :clip_keywords) } %>
-      <%= render partial: 'catalog/field_list',
-                 locals: { columns: 2,
-                           field_list: @document.labels_and_values( :event_date,
-                                                                    :event_location,
-                                                                    :program,
-                                                                    :series,
-                                                                    :category,
-                                                                    :length,
-                                                                    :aspect_ratio,
-                                                                    :codec,
-                                                                    :digital_wrapper,
-                                                                    :dimensions,
-                                                                    :format,
-                                                                    :type) } %>
-      </div>
+    <div class="pull-right col-md-3">
+      <%= render partial: 'shared/search', locals: {placeholder: "New search"} %>
     </div>
   </div>
-<% end %>
+  <div class="row">
+    <div class="col-md-6">
+      <video controls="true"
+        oncontextmenu="return false;" 
+        width="100%"
+        poster="<%= @document.thumb_src %>"
+        src="<%= @document.proxy_src %>">
+      </video>
+      <p>
+        TODO: Allison, put your message here.
+      </p>
+    </div>
+
+    <div class="col-md-6">
+    <%= render partial: 'catalog/field_list',
+               locals: { columns: 1,
+                         field_list: @document.labels_and_values( :clip_description,
+                                                                  :clip_keywords) } %>
+    <%= render partial: 'catalog/field_list',
+               locals: { columns: 2,
+                         field_list: @document.labels_and_values( :event_date,
+                                                                  :event_location,
+                                                                  :program,
+                                                                  :series,
+                                                                  :category,
+                                                                  :length,
+                                                                  :aspect_ratio,
+                                                                  :codec,
+                                                                  :digital_wrapper,
+                                                                  :dimensions,
+                                                                  :format,
+                                                                  :type) } %>
+    </div>
+  </div>
+</div>
 
 <br/>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -20,17 +20,27 @@
           TODO: Allison, put your message here.
         </p>
       </div>
-      <% [{ class: 'col-md-6', fields: %w(clip_description clip_keywords)},
-          { class: 'col-md-3', fields: %w(event_date event_location program series category)},
-          { class: 'col-md-3', fields: %w(length aspect_ratio codec digital_wrapper dimensions format type)}].each do |col| %>
-        <div class="<%= col[:class] %>">
-          <%= render partial: 'catalog/field_list', 
-                     locals: {
-                        asset: asset, 
-                        fields: col[:fields]
-                      } %>
-        </div>
-      <% end %>
+
+      <div class="col-md-6">
+      <%= render partial: 'catalog/field_list',
+                 locals: { columns: 1,
+                           field_list: @document.labels_and_values( :clip_description,
+                                                                    :clip_keywords) } %>
+      <%= render partial: 'catalog/field_list',
+                 locals: { columns: 2,
+                           field_list: @document.labels_and_values( :event_date,
+                                                                    :event_location,
+                                                                    :program,
+                                                                    :series,
+                                                                    :category,
+                                                                    :length,
+                                                                    :aspect_ratio,
+                                                                    :codec,
+                                                                    :digital_wrapper,
+                                                                    :dimensions,
+                                                                    :format,
+                                                                    :type) } %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -6,8 +6,8 @@ describe SolrDocument do
     %i(id artesia_id aspect_ratio barcode category ci_id clip_description
        clip_keywords clip_title codec digital_wrapper dimensions drive_name
        episode_number event_date event_location file_name folder_name format
-       frames_per_second id length origin program proxy_src series tape_number
-       thumb_src time_in type watermarked_src)
+       frames_per_second id length origin program series tape_number
+       thumb_src time_in type proxy_src watermarked_src)
   end
 
   # Specify one or more fields to be empty for testing purposes.
@@ -38,23 +38,11 @@ describe SolrDocument do
     end
   end
 
-  describe '#value_of' do
-    it 'returns the value of every field, whether it is part of the hash, or inside the serielized JSON' do
-      all_fields.each do |field|
-        if fields_with_empty_vals.include?(field)
-          expect(subject.value_of(field)).to be_empty
-        else
-          expect(subject.value_of(field)).to eq "value of #{field}"
-        end
-      end
-    end
-  end
-
   describe '#labels_and_values' do
     it 'returns a array of hashes of the form {label: "asset field", value: "asset field value"}' do
       labels_and_values = subject.labels_and_values(*all_fields)
       expect(labels_and_values.map{|pair| pair[:label] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.label_for(field) }
-      expect(labels_and_values.map{|pair| pair[:value] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.value_of(field) }
+      expect(labels_and_values.map{|pair| pair[:value] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.send(field) }
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -30,10 +30,10 @@ describe SolrDocument do
 
   subject { SolrDocument.new(hash_from_rsolr) }
 
-  describe '#label_for' do
+  describe '.label_for' do
     it 'returns a string for every field' do
       all_fields.each do |field|
-        expect(subject.label_for(field)).to be_a String
+        expect(SolrDocument.label_for(field)).to be_a String
       end
     end
   end
@@ -41,7 +41,7 @@ describe SolrDocument do
   describe '#labels_and_values' do
     it 'returns a array of hashes of the form {label: "asset field", value: "asset field value"}' do
       labels_and_values = subject.labels_and_values(*all_fields)
-      expect(labels_and_values.map{|pair| pair[:label] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.label_for(field) }
+      expect(labels_and_values.map{|pair| pair[:label] }).to eq (all_fields - fields_with_empty_vals).map{ |field| SolrDocument.label_for(field) }
       expect(labels_and_values.map{|pair| pair[:value] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.send(field) }
     end
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe SolrDocument do
+
+  let(:all_fields) do
+    %i(id artesia_id aspect_ratio barcode category ci_id clip_description
+       clip_keywords clip_title codec digital_wrapper dimensions drive_name
+       episode_number event_date event_location file_name folder_name format
+       frames_per_second id length origin program proxy_src series tape_number
+       thumb_src time_in type watermarked_src)
+  end
+
+  # Specify one or more fields to be empty for testing purposes.
+  let(:fields_with_empty_vals) { [:barcode] }
+
+  # Create a mock hash that emulates a hash returned from RSolr query.
+  let(:hash_from_rsolr) do
+    vals = all_fields.map do |field|
+      fields_with_empty_vals.include?(field) ? '' : "value of #{field}"
+    end
+
+    hash = Hash[all_fields.zip(vals)]
+    
+    hash_from_rsolr = {
+      id: hash[:id],
+      json: JSON.pretty_generate(hash),
+      text: hash.values
+    }
+  end
+
+  subject { SolrDocument.new(hash_from_rsolr) }
+
+  describe '#label_for' do
+    it 'returns a string for every field' do
+      all_fields.each do |field|
+        expect(subject.label_for(field)).to be_a String
+      end
+    end
+  end
+
+  describe '#value_of' do
+    it 'returns the value of every field, whether it is part of the hash, or inside the serielized JSON' do
+      all_fields.each do |field|
+        if fields_with_empty_vals.include?(field)
+          expect(subject.value_of(field)).to be_empty
+        else
+          expect(subject.value_of(field)).to eq "value of #{field}"
+        end
+      end
+    end
+  end
+
+  describe '#labels_and_values' do
+    it 'returns a array of hashes of the form {label: "asset field", value: "asset field value"}' do
+      labels_and_values = subject.labels_and_values(*all_fields)
+      expect(labels_and_values.map{|pair| pair[:label] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.label_for(field) }
+      expect(labels_and_values.map{|pair| pair[:value] }).to eq (all_fields - fields_with_empty_vals).map{ |field| subject.value_of(field) }
+    end
+  end
+end


### PR DESCRIPTION
@mccalluc take a look at this and tell me what you think.

I started poking around because of some tight coupling between views and the Asset model. It has become clear to me that our Asset model is pretty much trying to mimic what the SolrDocument model is designed to do, at least in the context of rendering solr data.

By default, Blacklight instantiates and returns SolrDocument object with the hash retrieved from solr when `#fetch` is called, and then passes `@document` or `documents` to it's default views.

By moving presentation logic from Asset to SolrDocument, we can avoid a layer of abstraction and extra steps to set up Asset instances that aren't really needed.