### PR TITLE
Adds tests for links in all Cmless pages.

### DIFF
--- a/spec/features/cmless_pages_spec.rb
+++ b/spec/features/cmless_pages_spec.rb
@@ -15,7 +15,9 @@ describe 'Cmless' do
     context "class #{klass}" do
 
       # Add the special methods used for testing Cmless classes.
-      klass.include CmlessTestingGoodies
+      # klass.include CmlessTestingGoodies
+      # CmlessTestingGoodies.add_to(klass)
+      klass.send(:include, CmlessTestingGoodies)
 
       # For each pages for the given Cmless class...
       klass.all.each do |cmless_page|
@@ -24,10 +26,10 @@ describe 'Cmless' do
         context "page \"#{cmless_page.title}\"" do
 
           # For each link within a given Cmless page instance...
-          cmless_page.__test.links.each do |link|
+          cmless_page.__test.external_links.each do |link|
 
             # In the context of a link within a Cmless page instance...
-            context "with link \"#{link}\"" do
+            context "with external link \"#{link}\"" do
               
               it "is a working link" do
                 expect(link).to be_a_working_link    

--- a/spec/features/cmless_pages_spec.rb
+++ b/spec/features/cmless_pages_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'support/cmless_testing_goodies.rb'
+
+
+describe 'Cmless' do
+
+  # Add any other Cmless classes to the @cmless_classes array.
+  # Tests within the @cmless_class.each loop should be generic enough for each
+  # class.
+  @cmless_classes = [About, Collection]
+
+  @cmless_classes.each do |klass|
+
+    # In the contet of a given class that inherits from Cmless...
+    context "class #{klass}" do
+
+      # Add the special methods used for testing Cmless classes.
+      klass.include CmlessTestingGoodies
+
+      # For each pages for the given Cmless class...
+      klass.all.each do |cmless_page|
+
+        # In the contest of a given Cmless page instance...
+        context "page \"#{cmless_page.title}\"" do
+
+          # For each link within a given Cmless page instance...
+          cmless_page.__test.links.each do |link|
+
+            # In the context of a link within a Cmless page instance...
+            context "with link \"#{link}\"" do
+              
+              it "is a working link" do
+                expect(link).to be_a_working_link    
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/cmless_testing_goodies.rb
+++ b/spec/support/cmless_testing_goodies.rb
@@ -3,6 +3,13 @@ require 'nokogiri'
 
 module CmlessTestingGoodies
 
+
+  # Provide a module method for mixing this module into a class.
+  # def self.add_to(klass)
+  #   klass.send(:include, self)
+  # end
+
+  # Accessor to the namespaced location for all the testing goodies methods.
   attr_reader :__test
 
   def initialize(file_path)
@@ -23,6 +30,10 @@ module CmlessTestingGoodies
 
     def links
       @links ||= (hrefs - mailtos - anchors)
+    end
+
+    def external_links
+      @external_links ||= links.grep(/^https?\:\/\//)
     end
 
     def anchors

--- a/spec/support/cmless_testing_goodies.rb
+++ b/spec/support/cmless_testing_goodies.rb
@@ -1,0 +1,40 @@
+require 'cmless'
+require 'nokogiri'
+
+module CmlessTestingGoodies
+
+  attr_reader :__test
+
+  def initialize(file_path)
+    # Creates a namespaced location for all of the actual testing goodies.
+    # This way it is hopefully unobtrusive
+    @__test = CmlessTestingGoodiesClass.new(file_path)
+    super
+  end
+
+
+  class CmlessTestingGoodiesClass
+
+    attr_reader :ng
+
+    def initialize(file_path)
+      @ng = Nokogiri::HTML(Cmless::Markdowner.instance.render(File.read(file_path)))
+    end
+
+    def links
+      @links ||= (hrefs - mailtos - anchors)
+    end
+
+    def anchors
+      @anchors ||= hrefs.grep(/^\#/)
+    end
+
+    def hrefs
+      @hrefs ||= ng.css('a').map { |link| link['href'] }
+    end
+
+    def mailtos
+      @mailto ||= hrefs.grep(/^mailto\:/)
+    end
+  end
+end

--- a/spec/support/link_check_matchers.rb
+++ b/spec/support/link_check_matchers.rb
@@ -11,3 +11,18 @@ RSpec::Matchers.define :be_a_valid_image_url do
     end
   end
 end
+
+RSpec::Matchers.define :be_a_working_link do
+  match do |check_link|
+    begin
+      # Accept all 2xx and 3xx as a good HTTP return status
+      good_statuses = (200..399)
+
+      binding.pry unless good_statuses.include?(Faraday.head(check_link).status)
+
+      good_statuses.include? Faraday.head(check_link).status
+    rescue
+      raise "Failed when checking URL: \"#{check_link}\""
+    end
+  end
+end


### PR DESCRIPTION
@mccalluc please review

I was going for an unobtrusive way to add some kind of inspection api to Cmless classes. Here's what I came up with.

Noticeably absent are tests for the `CmlessTestingGoodies` module and class, which would probably be a good idea, since we may come to rely on it for accuracy of our tests. I can be compelled to add some if you think they should be a part of this commit.

Caveat to this, is that we have broken links.. so this PR will introduce failing tests, which means it's working. Many of those links are either empty or "/TODO" (see output below).

We could fix all those links, or tweak these tests in order to prevent them from failing. I'm open