### PR TITLE
AAPB alpha logo. Fix #236

### DIFF
--- a/app/views/collections/aapb.md
+++ b/app/views/collections/aapb.md
@@ -2,6 +2,8 @@
 
 5
 
+![logo](https://s3.amazonaws.com/wgbhstocksales.org/content/collections/aapb/aapb-white-logo.png)
+
 ![thumb](https://s3.amazonaws.com/wgbhstocksales.org/content/collections/aapb/aapb-thumb_348x196.png)
 
 [![splash](https://s3.amazonaws.com/wgbhstocksales.org/content/collections/aapb/AAPB+home+page.png)](http://americanarchive.org/)


### PR DESCRIPTION
@afred? Grey speckles instead of pure white look good to me, but whatever.
![screen shot 2015-10-29 at 2 56 54 pm](https://cloud.githubusercontent.com/assets/730388/10828943/ac1512c4-7e4d-11e5-8634-372a665a3612.png)
```
convert ../AAPB2/public/site-ui/logo.png -negate - | \
convert - -alpha copy -fx '#fff' /tmp/aapb-white-logo.png
```