### PR TITLE
Padding around placeholder text. Fix #265.

### DIFF
--- a/app/assets/stylesheets/locals/search_form.css.scss
+++ b/app/assets/stylesheets/locals/search_form.css.scss
@@ -14,6 +14,9 @@
       background-color: $almost-white;
       color: #000;
       width: 90% !important;
+      &[placeholder] {
+          padding: 4px 8px;
+      }
       &[type="submit"] {
           // !important to make sure it applies on search results page.
           background-image: url(/icon-search.png) !important;


### PR DESCRIPTION
@afred? Also added a little padding on the top, because it looks weird without it.
![screen shot 2015-11-30 at 10 08 38 am](https://cloud.githubusercontent.com/assets/730388/11475240/4c0591fe-974a-11e5-891a-a969cb53a101.png)

(Another possibility would be just a nbsp in the placeholder text, but pretty sure that's not what you want.)
