### PR TITLE
No gutter around call-to-action.

### DIFF
--- a/app/assets/stylesheets/locals/masthead.css.scss
+++ b/app/assets/stylesheets/locals/masthead.css.scss
@@ -31,10 +31,18 @@
   }
 
   .call_to_action {
-    margin-top: $grid-gutter-width;
     @media (min-width: $screen-md-min) {
-        // With md or lg, separation from video.
-        margin-left: $grid-gutter-width;
+        height: 364px;
+        .body { padding-bottom: 0px; } 
+        // We get the padding we want by specifying height.
+    }
+    @media (min-width: $screen-lg-min) {
+        height: 462px;
+    }
+    @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+        .body .well {
+            min-height: auto; // Save vertical space inside.
+        } 
     }
   }
 }


### PR DESCRIPTION
@afred. This approach looks good in both md and lg, I think. I would really like to avoid moving the call-to-action down in md, for many reasons.
![screen shot 2015-12-01 at 5 54 28 pm](https://cloud.githubusercontent.com/assets/730388/11517053/324b015c-9855-11e5-8dfc-ef61a7d5e125.png)

Other thoughts:
- in lg, would we like the font to be larger? There's space.
- Maybe `WGBH&nbsp;programs` to control the flow?

Towards #262.