### PR TITLE
Smaller logo: baseline roughly aligns with blurb to right.

### DIFF
--- a/app/views/home/_masthead.html.erb
+++ b/app/views/home/_masthead.html.erb
@@ -3,7 +3,7 @@
     <div class="row top-row">
       <div class="col-md-8">
         <img src="https://s3.amazonaws.com/wgbhstocksales.org/content/home_page/logo-big.png" alt="WGBH Stock Sales &amp; Licensing"
-             style="height: auto; width: 75%; display: block;"/>
+             style="height: auto; width: 63%; display: block;"/>
       </div>
       <div class="col-md-4 pull-right tagline hidden-sm hidden-xs">
         <%# Line breaks to give us three even lines. %>


### PR DESCRIPTION
Fix #309, hopefully. @AlisonCSmith : This shrinks it by the ratio you requested. @afred?