### PR TITLE
Maybe empty string for variant is not valid?

### DIFF
--- a/public/fm_to_csv.xsl
+++ b/public/fm_to_csv.xsl
@@ -14,7 +14,7 @@
       Complete header from template:
       Handle,Title,Body (HTML),Vendor,Type,Tags,Published,Option1 Name,Option1 Value,Option2 Name,Option2 Value,Option3 Name,Option3 Value,Variant SKU,Variant Grams,Variant Inventory Tracker,Variant Inventory Qty,Variant Inventory Policy,Variant Fulfillment Service,Variant Price,Variant Compare At Price,Variant Requires Shipping,Variant Taxable,Variant Barcode,Image Src,Image Alt Text,Gift Card,Google Shopping / MPN,Google Shopping / Age Group,Google Shopping / Gender,Google Shopping / Google Product Category,SEO Title,SEO Description,Google Shopping / AdWords Grouping,Google Shopping / AdWords Labels,Google Shopping / Condition,Google Shopping / Custom Product,Google Shopping / Custom Label 0,Google Shopping / Custom Label 1,Google Shopping / Custom Label 2,Google Shopping / Custom Label 3,Google Shopping / Custom Label 4,Variant Image,Variant Weight Unit
     -->
-    <xsl:value-of select='"Handle,Title,Body (HTML),Published,Option1 Name,Option1 Value,Variant SKU,Variant Price,Image Src&#xA;"'/>
+    <xsl:value-of select='"Handle,Title,Body (HTML),Option1 Name,Option1 Value,Variant SKU,Variant Price,Image Src&#xA;"'/>
     <xsl:apply-templates select="fm:FMPDSORESULT/fm:ROW" />
   </xsl:template>
 
@@ -55,7 +55,6 @@
                             $id, $comma,
                             $q,translate($title,$qnl,'  '),$q, $comma,
                             $q,translate($description,$qnl,'  '),$q, $comma,
-                            'TRUE', $comma,
                             'Format', '&#xA;'
                           )"/>
   </xsl:template>
@@ -67,7 +66,6 @@
     <xsl:variable name="comma" select="','"/>
     <xsl:value-of select="concat(
                             $id, $comma,
-                            '', $comma,
                             '', $comma,
                             '', $comma,
                             'Format', $comma,

--- a/spec/fixtures/fm-export.csv
+++ b/spec/fixtures/fm-export.csv
@@ -1,3 +1,3 @@
-Handle,Title,Body (HTML),Published,Option1 Name,Option1 Value,Variant SKU,Variant Price,Image Src
-GBH000123,"gothic building","La Habana Vieja,  quotes and NL are ok ",TRUE,Format
-GBH000123,,,,Format,SD,GBH000123,$180,http://wgbhstocksales.org/thumb/GBH000123
+Handle,Title,Body (HTML),Option1 Name,Option1 Value,Variant SKU,Variant Price,Image Src
+GBH000123,"gothic building","La Habana Vieja,  quotes and NL are ok ",Format
+GBH000123,,,Format,SD,GBH000123,$180,http://wgbhstocksales.org/thumb/GBH000123


### PR DESCRIPTION
@afred? I'm bit confused by the current behavior, but I don't think the field is required, so this seems reasonable.

https://docs.shopify.com/manual/products/import-export says:
"Leaving the field blank will publish the product."