### PR TITLE
Make the input more obvious, at the request of Alison.

### DIFF
--- a/app/assets/stylesheets/locals/search_form.css.scss
+++ b/app/assets/stylesheets/locals/search_form.css.scss
@@ -13,17 +13,20 @@
       color: #000;
       width: 100% !important;
       &[placeholder] {
-          padding: 4px 8px;
+        padding: 4px 12px;
+        border: 0;
+        box-shadow: 0px 0px 10px $dark-blue;
+        border-radius: 20px;
       }
       &[type="submit"] {
-          // !important to make sure it applies on search results page.
-          background-image: url(/icon-search.png) !important;
-          background-repeat: no-repeat !important;
-          background-size: contain !important;
-          background-color: inherit !important;
-          border: none !important;
-          width: 30px !important;
-          margin-left: 5px;
+        // !important to make sure it applies on search results page.
+        background-image: url(/icon-search.png) !important;
+        background-repeat: no-repeat !important;
+        background-size: contain !important;
+        background-color: inherit !important;
+        border: none !important;
+        width: 30px !important;
+        margin-left: 5px;
       }
     }  
   } 


### PR DESCRIPTION
@afred? Also: I would also like the focus to be on that field... but `.focus` doesn't work?
<img width="399" alt="screen shot 2016-03-04 at 3 48 02 pm" src="https://cloud.githubusercontent.com/assets/730388/13539785/86db04f0-e220-11e5-8ee1-983bb3f2e35f.png">
